### PR TITLE
UDP Redirect Script

### DIFF
--- a/util/udpredirect.py
+++ b/util/udpredirect.py
@@ -1,0 +1,17 @@
+import socket, time, random
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+address = "192.168.1.118"
+port = 9999
+
+endpoint = (address, port)
+sock.bind(endpoint)
+
+while True:
+	data, sender_endpoint = sock.recvfrom(1500)
+	sender_endpoint_redirect = (sender_endpoint[0], sender_endpoint[1]+1)
+	print("Redirecting data from "+ str(sender_endpoint) + " back to " + str(sender_endpoint_redirect))
+	sent = sock.sendto(data, sender_endpoint_redirect)
+
+	time.sleep(55.0/1000)


### PR DESCRIPTION
Since you can't have two processes sending/receiving packets from the same port I've duplicated then edited `util/udpecho.py` to redirect the data packet coming from port number X to port number X+1 instead of just echoing back to port X.

This means data packets can be sent from port X on one machine (A) to another machine (B) which is running `util/udpecho.py`. We can then monitor port X+1 on machine A for the returning data packet with whatever process we want.