### PR TITLE
Fix repeat readout of last DE frame; configure downlink MTU by `systems.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@ doc/*
 log/*
 
 *mmap*
+
+debug/*
+
+env/
+venv/
+.env/
+.venv/

--- a/include/Buffers.h
+++ b/include/Buffers.h
@@ -43,7 +43,7 @@ class DownlinkBufferElement {
          * @brief Construct a new `DownlinkBufferElement` object from a source system and maximum allowable downlink packet size.
          * 
          * @param new_system the `System` object which generated the data for downlink.
-         * @param new_max_packet_size the maximum allowable size for a downlink packet. Related to downlink MTU.
+         * @param new_max_packet_size the maximum allowable size for a downlink packet (includes header). Related to downlink MTU.
          */
         DownlinkBufferElement(System* new_system, size_t new_max_packet_size);
 

--- a/src/TransportLayer.cpp
+++ b/src/TransportLayer.cpp
@@ -1125,10 +1125,10 @@ bool TransportLayerMachine::sync_udp_send_all_downlink_buffer() {
     // todo: replace this with non-dummy setup that adds enough max_packet_size to avoid errors when popping queue:
     // DownlinkBufferElement dbe(&(commands->get_sys_for_name("uplink")), 2000);
     DownlinkBufferElement dbe(
-        &(commands->get_sys_for_name("uplink")), 
-        commands->get_sys_for_name("uplink").ethernet->max_payload_size 
-            + commands->get_sys_for_name("uplink").ethernet->static_header_size 
-            + commands->get_sys_for_name("uplink").ethernet->static_footer_size
+        &(commands->get_sys_for_name("gse")), 
+        commands->get_sys_for_name("gse").ethernet->max_payload_size 
+            + commands->get_sys_for_name("gse").ethernet->static_header_size 
+            + commands->get_sys_for_name("gse").ethernet->static_footer_size
         );
     bool has_data = downlink_buffer->try_dequeue(dbe);
 

--- a/src/TransportLayer.cpp
+++ b/src/TransportLayer.cpp
@@ -1130,7 +1130,13 @@ bool TransportLayerMachine::sync_udp_send_all_downlink_buffer() {
     utilities::debug_print("in TransportLayerMachine::sync_udp_send_downlink_buffer()\n");
 
     // todo: replace this with non-dummy setup that adds enough max_packet_size to avoid errors when popping queue:
-    DownlinkBufferElement dbe(&(commands->get_sys_for_name("uplink")), 2000);
+    // DownlinkBufferElement dbe(&(commands->get_sys_for_name("uplink")), 2000);
+    DownlinkBufferElement dbe(
+        &(commands->get_sys_for_name("uplink")), 
+        commands->get_sys_for_name("uplink").ethernet->max_payload_size 
+            + commands->get_sys_for_name("uplink").ethernet->static_header_size 
+            + commands->get_sys_for_name("uplink").ethernet->static_footer_size
+    );
     bool has_data = downlink_buffer->try_dequeue(dbe);
 
     while (has_data && dbe.get_system().hex != 0x05) {


### PR DESCRIPTION
### Changes included

This PR changes two things:
1. Fixes issue #68, part 1. The Formatter should no longer repeatedly read the last saved CdTe frame. The fix is described in issue #68 and in the [v1.2.0 release notes](https://github.com/foxsi/foxsi-4matter/releases/tag/v1.2.0).
2. The maximum downlink packet size (related to Ethernet MTU) is now adapted based on values set in `foxsi4-commands/systems.json`, rather than being hard-coded at 2000 B. This should not actually change functionality over v1.2.0 until the downlink frame size is modified in the configuration file.

### Issues

There are not known issues at this point, but these changes must be validated on the flight system.