### PR TITLE
Remove some double-added lines in `foxsimile` source files from last merge

### DIFF
--- a/apps/foxsimile.cpp
+++ b/apps/foxsimile.cpp
@@ -16,11 +16,8 @@
 #include <iostream>
 
 int main(int argc, char** argv) {
-int main(int argc, char** argv) {
     boost::asio::io_context context;
     LineInterface lif(argc, argv, context);
-    auto deck_basic = lif.get_command_deck();
-    auto deck = std::make_shared<CommandDeck>(deck_basic);
     auto deck_basic = lif.get_command_deck();
     auto deck = std::make_shared<CommandDeck>(deck_basic);
 

--- a/src/Foxsimile.cpp
+++ b/src/Foxsimile.cpp
@@ -133,18 +133,12 @@ void foxsimile::Responder::async_receive() {
         boost::bind(&Responder::await_full_buffer, this,
                     boost::asio::placeholders::error,
                     boost::asio::placeholders::bytes_transferred));
-        boost::bind(&Responder::await_full_buffer, this,
-                    boost::asio::placeholders::error,
-                    boost::asio::placeholders::bytes_transferred));
 }
 
-void foxsimile::Responder::handle_accept(const boost::system::error_code& err) {
 void foxsimile::Responder::handle_accept(const boost::system::error_code& err) {
     if (!err) {
         std::cout << name << " accepted!\n";
         async_receive();
-        // frame_timer->async_wait(boost::bind(&Responder::handle_frame_timer,
-        // this));
         // frame_timer->async_wait(boost::bind(&Responder::handle_frame_timer,
         // this));
     } else {
@@ -152,8 +146,6 @@ void foxsimile::Responder::handle_accept(const boost::system::error_code& err) {
     }
 }
 
-void foxsimile::Responder::await_full_buffer(
-    const boost::system::error_code& err, std::size_t byte_count) {
 void foxsimile::Responder::await_full_buffer(
     const boost::system::error_code& err, std::size_t byte_count) {
 
@@ -182,8 +174,6 @@ void foxsimile::Responder::await_full_buffer(
     size_t current_accumulator_index = message_accumulator.size();
     message_accumulator.insert(message_accumulator.end(), read_buffer.begin(),
                                read_buffer.end());
-    message_accumulator.insert(message_accumulator.end(), read_buffer.begin(),
-                               read_buffer.end());
 
     // std::cout << name << " accumulator fill: ";
     // utilities::hex_print(message_accumulator);
@@ -194,10 +184,6 @@ void foxsimile::Responder::await_full_buffer(
     // check we can read 12 bytes in:
     if (message_accumulator.size() >= 12) {
         // split into header and footer, convert footer to a uint
-        std::vector<uint8_t> head(message_accumulator.begin() + 8,
-                                  message_accumulator.begin() + 12);
-        std::vector<uint8_t> foot(message_accumulator.begin() + 12,
-                                  message_accumulator.end());
         std::vector<uint8_t> head(message_accumulator.begin() + 8,
                                   message_accumulator.begin() + 12);
         std::vector<uint8_t> foot(message_accumulator.begin() + 12,
@@ -222,20 +208,11 @@ void foxsimile::Responder::await_full_buffer(
             message_accumulator.erase(message_accumulator.begin(),
                                       message_accumulator.begin() +
                                           purported_length);
-            std::vector<uint8_t> working_buffer(message_accumulator.begin(),
-                                                message_accumulator.begin() +
-                                                    12 + purported_length);
-            message_accumulator.erase(message_accumulator.begin(),
-                                      message_accumulator.begin() +
-                                          purported_length);
 
             // trim ethernet header before handing to lookup?
 
             // send it out.
             send_response(get_response(working_buffer));
-
-            // clear accumulated buffer
-            message_accumulator.resize(0);
 
             // clear accumulated buffer
             message_accumulator.resize(0);
@@ -246,12 +223,7 @@ void foxsimile::Responder::await_full_buffer(
                 std::cout << "probably for housekeeping.\n";
                 std::vector<uint8_t> working_buffer(message_accumulator.begin(),
                                                     message_accumulator.end());
-                std::vector<uint8_t> working_buffer(message_accumulator.begin(),
-                                                    message_accumulator.end());
                 send_response(get_response(working_buffer));
-                
-                // clear accumulated buffer
-                message_accumulator.resize(0);
                 
                 // clear accumulated buffer
                 message_accumulator.resize(0);
@@ -288,13 +260,8 @@ void foxsimile::Responder::end_session() {
     acceptor.async_accept(socket,
                           boost::bind(&Responder::handle_accept, this,
                                       boost::asio::placeholders::error));
-    acceptor.async_accept(socket,
-                          boost::bind(&Responder::handle_accept, this,
-                                      boost::asio::placeholders::error));
 }
 
-std::vector<uint8_t>
-foxsimile::Responder::get_response(std::vector<uint8_t> message) {
 std::vector<uint8_t>
 foxsimile::Responder::get_response(std::vector<uint8_t> message) {
     std::vector<uint8_t> response;
@@ -312,9 +279,6 @@ foxsimile::Responder::get_response(std::vector<uint8_t> message) {
     return response;
 }
 
-bool foxsimile::Responder::add_response(std::vector<uint8_t> message,
-                                        std::vector<uint8_t> response) {
-    return response_lookup.insert(std::make_pair(message, response)).second;
 bool foxsimile::Responder::add_response(std::vector<uint8_t> message,
                                         std::vector<uint8_t> response) {
     return response_lookup.insert(std::make_pair(message, response)).second;
@@ -401,8 +365,6 @@ void foxsimile::Responder::handle_frame_timer() {
 
 std::vector<uint8_t>
 foxsimile::Responder::make_reply(std::vector<uint8_t> message) {
-std::vector<uint8_t>
-foxsimile::Responder::make_reply(std::vector<uint8_t> message) {
     std::vector<uint8_t> response;
     size_t eth_head_size = 12;
 
@@ -415,12 +377,8 @@ foxsimile::Responder::make_reply(std::vector<uint8_t> message) {
     if (message_size < eth_head_size) {
         throw "can't foxsimile::Responder::make_reply(): message size way too "
               "short";
-        throw "can't foxsimile::Responder::make_reply(): message size way too "
-              "short";
     }
 
-    std::vector<uint8_t> tail_size_bytes(message.begin() + 7,
-                                         message.begin() + eth_head_size - 1);
     std::vector<uint8_t> tail_size_bytes(message.begin() + 7,
                                          message.begin() + eth_head_size - 1);
     size_t tail_size = utilities::unsplat_from_4bytes(tail_size_bytes);
@@ -460,29 +418,17 @@ foxsimile::Responder::make_reply(std::vector<uint8_t> message) {
     size_t address_offset_from_reply_address                   = 4;
     size_t data_length_offset_from_reply_address               = 8;
     size_t data_offset_from_reply_address                      = 12;
-    size_t transaction_id_offset_from_reply_address            = 1;
-    size_t extended_address_offset_from_reply_address          = 3;
-    size_t address_offset_from_reply_address                   = 4;
-    size_t data_length_offset_from_reply_address               = 8;
-    size_t data_offset_from_reply_address                      = 12;
 
     uint8_t instruction =
         tail.at(target_path_address.size() + instruction_offset_from_start);
-    uint8_t instruction =
-        tail.at(target_path_address.size() + instruction_offset_from_start);
     uint8_t key = tail.at(target_path_address.size() + key_offset_from_start);
-    std::cout << "received instruction: " << std::to_string(instruction)
-              << "\n";
     std::cout << "received instruction: " << std::to_string(instruction)
               << "\n";
 
     // checking instruction for how to respond:
     bool do_write  = instruction & 0x20; // check RMAP write (1) or read (0).
     bool do_reply  = instruction & 0x08;
-    bool do_write  = instruction & 0x20; // check RMAP write (1) or read (0).
-    bool do_reply  = instruction & 0x08;
     bool do_verify = instruction & 0x10;
-    uint8_t instruction_reply_size = 4 * (instruction & 0x03);
     uint8_t instruction_reply_size = 4 * (instruction & 0x03);
 
     std::vector<uint8_t> explicit_reply_path_address(
@@ -490,14 +436,8 @@ foxsimile::Responder::make_reply(std::vector<uint8_t> message) {
             target_path_address.size(),
         tail.begin() + reply_path_offset_from_start +
             target_path_address.size() + instruction_reply_size);
-        tail.begin() + reply_path_offset_from_start +
-            target_path_address.size(),
-        tail.begin() + reply_path_offset_from_start +
-            target_path_address.size() + instruction_reply_size);
     std::vector<uint8_t> reply_path_address(explicit_reply_path_address);
 
-    // delete extra (padding to multiple of 4) nodes from the path address for
-    // response
     // delete extra (padding to multiple of 4) nodes from the path address for
     // response
     uint8_t reply_first_node = 0;
@@ -507,8 +447,6 @@ foxsimile::Responder::make_reply(std::vector<uint8_t> message) {
             break;
         }
     }
-    reply_path_address.erase(reply_path_address.begin(),
-                             reply_path_address.begin() + reply_first_node);
     reply_path_address.erase(reply_path_address.begin(),
                              reply_path_address.begin() + reply_first_node);
 
@@ -524,20 +462,7 @@ foxsimile::Responder::make_reply(std::vector<uint8_t> message) {
         tail.at(target_path_address.size() + reply_path_offset_from_start +
                 instruction_reply_size +
                 initiator_logical_address_offset_from_reply_address);
-    uint8_t initiator_logical_address =
-        tail.at(target_path_address.size() + reply_path_offset_from_start +
-                instruction_reply_size +
-                initiator_logical_address_offset_from_reply_address);
     std::vector<uint8_t> transaction_id(
-        tail.begin() + target_path_address.size() +
-            reply_path_offset_from_start + instruction_reply_size +
-            transaction_id_offset_from_reply_address,
-        tail.begin() + target_path_address.size() +
-            reply_path_offset_from_start + instruction_reply_size +
-            transaction_id_offset_from_reply_address + 1);
-    uint8_t extended_address = tail.at(
-        target_path_address.size() + reply_path_offset_from_start +
-        instruction_reply_size + extended_address_offset_from_reply_address);
         tail.begin() + target_path_address.size() +
             reply_path_offset_from_start + instruction_reply_size +
             transaction_id_offset_from_reply_address,
@@ -554,12 +479,6 @@ foxsimile::Responder::make_reply(std::vector<uint8_t> message) {
         tail.begin() + target_path_address.size() +
             reply_path_offset_from_start + instruction_reply_size +
             address_offset_from_reply_address + 4);
-        tail.begin() + target_path_address.size() +
-            reply_path_offset_from_start + instruction_reply_size +
-            address_offset_from_reply_address,
-        tail.begin() + target_path_address.size() +
-            reply_path_offset_from_start + instruction_reply_size +
-            address_offset_from_reply_address + 4);
     std::vector<uint8_t> data_length_bytes(
         tail.begin() + target_path_address.size() +
             reply_path_offset_from_start + instruction_reply_size +
@@ -567,12 +486,6 @@ foxsimile::Responder::make_reply(std::vector<uint8_t> message) {
         tail.begin() + target_path_address.size() +
             reply_path_offset_from_start + instruction_reply_size +
             data_length_offset_from_reply_address + 3);
-        tail.begin() + target_path_address.size() +
-            reply_path_offset_from_start + instruction_reply_size +
-            data_length_offset_from_reply_address,
-        tail.begin() + target_path_address.size() +
-            reply_path_offset_from_start + instruction_reply_size +
-            data_length_offset_from_reply_address + 3);
 
     size_t data_length = (data_length_bytes[0] << 16) & 0xff0000 |
                          (data_length_bytes[1] << 8) & 0x00ff00 |
@@ -581,18 +494,7 @@ foxsimile::Responder::make_reply(std::vector<uint8_t> message) {
                      (address_bytes[1] << 16) & 0x00ff'0000 |
                      (address_bytes[2] << 8) & 0x0000'ff00 |
                      (address_bytes[3] << 0) & 0x0000'00ff;
-    size_t data_length = (data_length_bytes[0] << 16) & 0xff0000 |
-                         (data_length_bytes[1] << 8) & 0x00ff00 |
-                         (data_length_bytes[2] << 0) & 0x0000ff;
-    size_t address = (address_bytes[0] << 24) & 0xff00'0000 |
-                     (address_bytes[1] << 16) & 0x00ff'0000 |
-                     (address_bytes[2] << 8) & 0x0000'ff00 |
-                     (address_bytes[3] << 0) & 0x0000'00ff;
 
-    std::cout << "initiator logical address: "
-              << std::to_string(initiator_logical_address) << "\n";
-    std::cout << "requesting access to " << std::to_string(data_length)
-              << " bytes from address ";
     std::cout << "initiator logical address: "
               << std::to_string(initiator_logical_address) << "\n";
     std::cout << "requesting access to " << std::to_string(data_length)
@@ -618,12 +520,6 @@ foxsimile::Responder::make_reply(std::vector<uint8_t> message) {
         std::cout << "got write command\n";
         // extract data to write:
         std::vector<uint8_t> data_bytes(
-            tail.begin() + target_path_address.size() +
-                reply_path_offset_from_start + instruction_reply_size +
-                data_offset_from_reply_address,
-            tail.begin() + target_path_address.size() +
-                reply_path_offset_from_start + instruction_reply_size +
-                data_offset_from_reply_address + data_length);
             tail.begin() + target_path_address.size() +
                 reply_path_offset_from_start + instruction_reply_size +
                 data_offset_from_reply_address,
@@ -707,7 +603,6 @@ RING_BUFFER_TYPE_OPTIONS foxsimile::mmap::is_ring_buffer(System& sys,
     // assumes convex (contiguous) ring buffer area.
     size_t first = address;
     size_t last  = address + offset;
-    size_t last  = address + offset;
 
     if (sys.name.find("cdte1") != std::string::npos) {
         if (first >= 0x0040'0000 && last < 0x022a'2df0) {
@@ -742,15 +637,9 @@ void foxsimile::mmap::advance_write_pointer(System& system,
     // check this is system with a ring buffer, and set stride accordingly.
 
     uint32_t stride   = 0;
-
-    uint32_t stride   = 0;
     uint32_t mod_size = 0;
     uint32_t start    = 0;
-    uint32_t start    = 0;
     if (system.name.find("cdte") != std::string::npos) {
-        stride   = system.ring_params.at(type).frame_size_bytes;
-        start    = system.ring_params.at(type).start_address;
-        mod_size = 980 * stride; // 0x01ea'2df0
         stride   = system.ring_params.at(type).frame_size_bytes;
         start    = system.ring_params.at(type).start_address;
         mod_size = 980 * stride; // 0x01ea'2df0
@@ -759,13 +648,7 @@ void foxsimile::mmap::advance_write_pointer(System& system,
             stride   = 0x1b'0000;
             start    = system.ring_params.at(type).start_address;
             mod_size = 32 * stride;
-            stride   = 0x1b'0000;
-            start    = system.ring_params.at(type).start_address;
-            mod_size = 32 * stride;
         } else if (type == RING_BUFFER_TYPE_OPTIONS ::QL) {
-            stride   = 0x22'0000;
-            start    = system.ring_params.at(type).start_address;
-            mod_size = 32 * stride;
             stride   = 0x22'0000;
             start    = system.ring_params.at(type).start_address;
             mod_size = 32 * stride;
@@ -788,8 +671,6 @@ void foxsimile::mmap::advance_write_pointer(System& system,
     if (new_write_pointer > mod_size + start) {
         new_write_pointer = start;
     }
-    std::vector<uint8_t> new_write_pointer_bytes =
-        utilities::splat_to_nbytes(4, new_write_pointer);
     std::vector<uint8_t> new_write_pointer_bytes =
         utilities::splat_to_nbytes(4, new_write_pointer);
     for (size_t i = 0; i < write_pointer_size; ++i) {


### PR DESCRIPTION
A prior merge added some lines in `Foxsimile.h`, `Foxsimile.cpp`, and `apps/foxsimile.cpp` twice. This reverts those changes. Also updates the `foxsi4-commands` submodule to the latest main branch.