### PR TITLE
Documentation for `systemd`, `systemctl`, and `formatter.service`

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ sudo systemctl disable formatter.service
 sudo systemctl enable formatter.service        
 ```
 
+If you need to set up `formatter.service` from scratch to run on boot, see [PISETUP.md](PISETUP.md). If you need to find and modify the `formatter.service` unit file, it is in `/etc/systemd/system/` on the FOXSI-4 flight Pi. 
+
 When the service is running, if you need to debug you will need to find the correct `~/foxsi-4matter/log/` file to collect evidence. This can be inconvenient to track down since Unixtime changes with every reboot. 
 
 A helpful debugging workflow is to stop the Formatter service, then launch it manually so you can see the stdout output:

--- a/util/formatter.service
+++ b/util/formatter.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Begin running formatter on boot.
+After=multi-user.target
+Requires=network.target
+
+[Service]
+Type=idle
+User=foxsi
+WorkingDirectory=/home/foxsi/foxsi-4matter
+Environment="ARG1=--verbose" "ARG2=--config" "ARG3=foxsi4-commands/systems.json"
+ExecStartPre=/bin/sleep 10
+ExecStart=nohup bin/formatter $ARG1 $ARG2 $ARG3 &
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Just modifies README and PISETUP, and adds the `systemd` unit file `formatter.service` that runs the formatter software on boot/reruns when errors occur.