### PR TITLE
Implement uplink command to clear formatter logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,12 @@ set(GOOGLETEST_ROOT /usr/local/include)
 set(spdlog_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include/spdlog)
 add_compile_definitions(SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
 
+set(CMAKE_MESSAGE_LOG_LEVEL WARNING)
+
 # enable_testing()
+
+# change to 1 to build *all* executables
+set(EXTRAS_FLAG 0)
 
 # add_compile_options("$<$<CONFIG:Debug>:-Og>")
 
@@ -75,31 +80,6 @@ target_include_directories(
     PRIVATE 
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
-
-# Build the target "shutdown" using source files
-add_executable(shutdown ${CMAKE_CURRENT_SOURCE_DIR}/apps/shutdown_systems.cpp)
-target_include_directories(
-    shutdown
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-# Build the target "stop" using source files
-add_executable(stop ${CMAKE_CURRENT_SOURCE_DIR}/apps/stop_systems.cpp)
-target_include_directories(
-    stop
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-# Build the target "log" using source files
-add_executable(log ${CMAKE_CURRENT_SOURCE_DIR}/apps/log.cpp)
-target_include_directories(
-    log
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
 # Build the target "foxsimile" using source files
 add_executable(foxsimile ${CMAKE_CURRENT_SOURCE_DIR}/apps/foxsimile.cpp)
 target_include_directories(
@@ -107,39 +87,6 @@ target_include_directories(
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
-
-# Build the target "test_spw_crc" using source files
-add_executable(test_spw_crc ${CMAKE_CURRENT_SOURCE_DIR}/test/spw_crc.cpp)
-target_include_directories(
-    test_spw_crc
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-# Build the target "test_spw_ping" using source files
-add_executable(test_spw_ping ${CMAKE_CURRENT_SOURCE_DIR}/test/test_spw_ping.cpp)
-target_include_directories(
-    test_spw_ping
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-# Build the target "test_spw_reply" using source files
-add_executable(test_spw_reply ${CMAKE_CURRENT_SOURCE_DIR}/test/test_spw_reply.cpp)
-target_include_directories(
-    test_spw_reply
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-# Build the target "test_loop" using source files
-add_executable(test_loop ${CMAKE_CURRENT_SOURCE_DIR}/test/test_loop.cpp)
-target_include_directories(
-    test_loop
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
 # Build the target "test_buffer" using source files
 add_executable(test_buffers ${CMAKE_CURRENT_SOURCE_DIR}/test/test_buffers.cpp)
 target_include_directories(
@@ -148,21 +95,80 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Build the target "test_uart" using source files
-add_executable(test_uart ${CMAKE_CURRENT_SOURCE_DIR}/test/test_uart.cpp)
-target_include_directories(
-    test_uart
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
+# additional targets
+if(EXTRAS_FLAG)
+    # Build the target "shutdown" using source files
+    add_executable(shutdown ${CMAKE_CURRENT_SOURCE_DIR}/apps/shutdown_systems.cpp)
+    target_include_directories(
+        shutdown
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
 
-# add_test(test ${CMAKE_CURRENT_SOURCE_DIR}/test/test.cpp
-add_executable(test ${CMAKE_CURRENT_SOURCE_DIR}/test/test.cpp)
-target_include_directories(
-    test
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
+    # Build the target "stop" using source files
+    add_executable(stop ${CMAKE_CURRENT_SOURCE_DIR}/apps/stop_systems.cpp)
+    target_include_directories(
+        stop
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+
+    # Build the target "log" using source files
+    add_executable(log ${CMAKE_CURRENT_SOURCE_DIR}/apps/log.cpp)
+    target_include_directories(
+        log
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+
+    # Build the target "test_spw_crc" using source files
+    add_executable(test_spw_crc ${CMAKE_CURRENT_SOURCE_DIR}/test/spw_crc.cpp)
+    target_include_directories(
+        test_spw_crc
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+
+    # Build the target "test_spw_ping" using source files
+    add_executable(test_spw_ping ${CMAKE_CURRENT_SOURCE_DIR}/test/test_spw_ping.cpp)
+    target_include_directories(
+        test_spw_ping
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+
+    # Build the target "test_spw_reply" using source files
+    add_executable(test_spw_reply ${CMAKE_CURRENT_SOURCE_DIR}/test/test_spw_reply.cpp)
+    target_include_directories(
+        test_spw_reply
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+
+    # Build the target "test_loop" using source files
+    add_executable(test_loop ${CMAKE_CURRENT_SOURCE_DIR}/test/test_loop.cpp)
+    target_include_directories(
+        test_loop
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+
+    # Build the target "test_uart" using source files
+    add_executable(test_uart ${CMAKE_CURRENT_SOURCE_DIR}/test/test_uart.cpp)
+    target_include_directories(
+        test_uart
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+
+    # add_test(test ${CMAKE_CURRENT_SOURCE_DIR}/test/test.cpp
+    add_executable(test ${CMAKE_CURRENT_SOURCE_DIR}/test/test.cpp)
+    target_include_directories(
+        test
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+endif()
 
 # Check which OS we're using to use correct thread library
 if(UNIX AND NOT APPLE)
@@ -175,17 +181,20 @@ if(UNIX AND NOT APPLE)
     target_link_libraries(libutil PRIVATE Threads::Threads)
     target_link_libraries(libgse PRIVATE Threads::Threads)
     target_link_libraries(formatter PRIVATE Threads::Threads)
-    target_link_libraries(stop PRIVATE Threads::Threads)
-    target_link_libraries(shutdown PRIVATE Threads::Threads)
-    target_link_libraries(log PRIVATE Threads::Threads)
     target_link_libraries(foxsimile PRIVATE Threads::Threads)
-    target_link_libraries(test_spw_crc PRIVATE Threads::Threads)
-    target_link_libraries(test_spw_ping PRIVATE Threads::Threads)
-    target_link_libraries(test_spw_reply PRIVATE Threads::Threads)
-    target_link_libraries(test_loop PRIVATE Threads::Threads)
     target_link_libraries(test_buffers PRIVATE Threads::Threads)
-    target_link_libraries(test PRIVATE Threads::Threads)
-    target_link_libraries(test_uart PRIVATE Threads::Threads)
+
+    if(EXTRAS_FLAG)
+        target_link_libraries(stop PRIVATE Threads::Threads)
+        target_link_libraries(shutdown PRIVATE Threads::Threads)
+        target_link_libraries(log PRIVATE Threads::Threads)
+        target_link_libraries(test_spw_crc PRIVATE Threads::Threads)
+        target_link_libraries(test_spw_ping PRIVATE Threads::Threads)
+        target_link_libraries(test_spw_reply PRIVATE Threads::Threads)
+        target_link_libraries(test_loop PRIVATE Threads::Threads)
+        target_link_libraries(test PRIVATE Threads::Threads)
+        target_link_libraries(test_uart PRIVATE Threads::Threads)
+    endif()
 
     target_include_directories(
         libcom
@@ -228,17 +237,19 @@ if(Boost_FOUND)
    
     # then link them all to the executables
     target_link_libraries(formatter         PUBLIC libcom libsubsys libutil)
-    target_link_libraries(stop              PUBLIC libcom libsubsys libutil)
-    target_link_libraries(shutdown          PUBLIC libcom libsubsys libutil)
-    target_link_libraries(log               PUBLIC libcom libsubsys libutil libgse)
     target_link_libraries(foxsimile         PUBLIC libcom libsubsys libutil libgse)
-    target_link_libraries(test_spw_crc      PUBLIC libcom libsubsys libutil)
-    target_link_libraries(test_spw_ping     PUBLIC libcom libsubsys libutil)
-    target_link_libraries(test_spw_reply    PUBLIC libcom libsubsys libutil)
-    target_link_libraries(test_loop         PUBLIC libcom libsubsys libutil)
     target_link_libraries(test_buffers      PUBLIC libcom libsubsys libutil)
-    target_link_libraries(test              PUBLIC libcom libsubsys libutil)
-    target_link_libraries(test_uart         PUBLIC libcom libsubsys libutil)
+    if(EXTRAS_FLAG)
+        target_link_libraries(stop              PUBLIC libcom libsubsys libutil)
+        target_link_libraries(shutdown          PUBLIC libcom libsubsys libutil)
+        target_link_libraries(log               PUBLIC libcom libsubsys libutil libgse)
+        target_link_libraries(test_spw_crc      PUBLIC libcom libsubsys libutil)
+        target_link_libraries(test_spw_ping     PUBLIC libcom libsubsys libutil)
+        target_link_libraries(test_spw_reply    PUBLIC libcom libsubsys libutil)
+        target_link_libraries(test_loop         PUBLIC libcom libsubsys libutil)
+        target_link_libraries(test              PUBLIC libcom libsubsys libutil)
+        target_link_libraries(test_uart         PUBLIC libcom libsubsys libutil)
+    endif()
 elseif(NOT Boost_FOUND)
     error("Boost not found.")
 endif()

--- a/include/Utilities.h
+++ b/include/Utilities.h
@@ -131,6 +131,11 @@ namespace utilities{
     void error_log(std::vector<uint8_t> data);
 
     /**
+     * @brief Delete formatter log files and syslog/daemon.log.
+     */
+    int clear_formatter_log();
+
+    /**
      * @brief Print a `std::string` to stdout, colored blue (debug).
      * @param msg the string to print.
      */

--- a/src/Circle.cpp
+++ b/src/Circle.cpp
@@ -798,19 +798,15 @@ std::vector<uint8_t> Circle::make_global_health_packet() {
         content[k++] = static_cast<uint8_t>((system_order[i]->errors >> 8 & 0xff));
         content[k++] = static_cast<uint8_t>((system_order[i]->errors & 0xff));
     }
-    utilities::debug_print("\t...post-loop.");
 
     auto this_time = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     uint32_t out_time = static_cast<uint32_t>(this_time & 0xffffffff);
     auto time_bytes = utilities::splat_to_nbytes(4, out_time);
-
-    utilities::debug_print("\t...post-splat.");
 
     std::vector<uint8_t> packet;
     packet.insert(packet.end(), time_bytes.begin(), time_bytes.end());
     packet.push_back(0x00);
     packet.push_back(0x00);
     packet.insert(packet.end(), content.begin(), content.end());
-    utilities::debug_print("\t...packet done.");
     return packet;
 }

--- a/src/TransportLayer.cpp
+++ b/src/TransportLayer.cpp
@@ -262,6 +262,12 @@ bool TransportLayerMachine::handle_intercept_cmd(SystemManager& sys_man, Command
     utilities::debug_log("TransportLayerMachine::handle_intercept_cmd()\thandling intercept command " + std::to_string(cmd.hex) + " for system " + std::to_string(sys_man.system.hex));
 
     if (sys_man.system.name == "housekeeping") {
+        // command to clear formatter logs. This is not actually used by the housekeeping board, but categorized under that system.
+        if (0x3f == cmd.hex) {
+            int success = utilities::clear_formatter_log();
+            utilities::debug_log("TransportLayerMachine::handle_intercept_cmd()\ttried clearing logs and got " + std::to_string(success) + " result.");
+            return true;
+        }
         // note here we are directly using the command hex code, not the content of the command.
         if (sys_man.system_state != SYSTEM_STATE::DISCONNECT && sys_man.system_state != SYSTEM_STATE::ABANDON) {
             if (0x30 == cmd.hex) {


### PR DESCRIPTION
### Changes

#### Log file deletion
This implements a new behavior triggered by the uplink command `housekeeping > clear_formatter_logs` or `0x02 > 0x3f`. The new uplink command is included in the [foxsi4-commands v1.1.2 release](https://github.com/foxsi/foxsi4-commands/releases/tag/v1.1.2).

The new behavior is implemented between `TransportLayerMachine::handle_intercept_cmd()` and `utilities::clear_formatter_log()`. This new command is implemented as an intercept command—it is not forwarded to the Housekeeping board but acted on locally by the Formatter. Upon receipt, Formatter will search through the folder `/home/foxsi/foxsi-4matter/log/` for log files. It will compare each file in that folder to the file being written by `utilities::logger` (the current active log file). All log files except the current log file will be deleted.

System-level log files (in `/var/log/`) are not truncated by this command, those require privileged access. Instead, I locally modified `/etc/logrotate.conf` to save fewer of those system-level logs and keep them smaller.

### CMake changes
I added a flag `EXTRAS_FLAG` to the main project CMakeLists.txt file. This flag toggles building of all the non-essential targets that have been included over the years for testing and debug purposes.

`EXTRAS_FLAG` is not set by default, and in this configuration only the targets `formatter`, `test_buffers`, and `foxsimile` are built (as well as supporting libraries). This speeds up the build process on the Pi significantly.

### Validation
I confirmed the new uplink command behavior on 20 May 2025. Log files are removed as expected and the current log file remains untouched.